### PR TITLE
Fix Model bugs with DropDown and List when using DataContext

### DIFF
--- a/TestApp/lib/TestFunctions.cs
+++ b/TestApp/lib/TestFunctions.cs
@@ -693,6 +693,11 @@ namespace TestApp.lib
                     })
                     .HorizontalGroup(h =>
                     {
+                        h.Text("Saved Contacts: ")
+                            .DropDown<model.Contact>(itemSourceModelName: "savedContacts", selectedItemModelName: "Contact");
+                    })
+                    .HorizontalGroup(h =>
+                    {
                         h.Text("Results: ")
                             .TextBoxFor("Results", multiline: true, style: new nac.Forms.model.Style
                             {

--- a/TestApp/lib/TestFunctions.cs
+++ b/TestApp/lib/TestFunctions.cs
@@ -690,11 +690,23 @@ namespace TestApp.lib
                             Display Name: {model.Contact.DisplayName}
                             Email: {model.Contact.Email}
                             ";
+                        model.savedContacts.Add(model.Contact);
+                        model.Contact = new model.Contact
+                        {
+                            Email = model.Contact.Email,
+                            DisplayName = model.Contact.DisplayName
+                        };
                     })
                     .HorizontalGroup(h =>
                     {
                         h.Text("Saved Contacts: ")
-                            .DropDown<model.Contact>(itemSourceModelName: "savedContacts", selectedItemModelName: "Contact");
+                            .DropDown<model.Contact>(itemSourceModelName: "savedContacts", selectedItemModelName: "Contact",
+                                populateItemRow: (r)=> r.HorizontalGroup(h=>
+                                {
+                                    h.Text("Email: ")
+                                    .TextFor("Email");
+                                })
+                                );
                     })
                     .HorizontalGroup(h =>
                     {

--- a/TestApp/lib/TestFunctions.cs
+++ b/TestApp/lib/TestFunctions.cs
@@ -684,29 +684,36 @@ namespace TestApp.lib
                         h.Text("Email: ")
                             .TextBoxFor("Contact.Email");
                     })
-                    .Button("save", (obj) =>
+                    .HorizontalGroup(h =>
                     {
-                        model.Results = $@"
+                        h.Button("New", (obj) =>
+                        {
+                            model.Contact = new model.Contact();
+                        }).Button("save", (obj) =>
+                        {
+                            model.Results = $@"
                             Display Name: {model.Contact.DisplayName}
                             Email: {model.Contact.Email}
                             ";
-                        model.savedContacts.Add(model.Contact);
-                        model.Contact = new model.Contact
-                        {
-                            Email = model.Contact.Email,
-                            DisplayName = model.Contact.DisplayName
-                        };
+                            model.savedContacts.Add(model.Contact);
+                            model.Contact = new model.Contact
+                            {
+                                Email = model.Contact.Email,
+                                DisplayName = model.Contact.DisplayName
+                            };
+                        });
                     })
                     .HorizontalGroup(h =>
                     {
                         h.Text("Saved Contacts: ")
-                            .DropDown<model.Contact>(itemSourceModelName: "savedContacts", selectedItemModelName: "Contact",
-                                populateItemRow: (r)=> r.HorizontalGroup(h=>
+                            .DropDown<model.Contact>(itemSourceModelName: "savedContacts",
+                                selectedItemModelName: "Contact",
+                                populateItemRow: (r) => r.HorizontalGroup(h =>
                                 {
                                     h.Text("Email: ")
-                                    .TextFor("Email");
+                                        .TextFor("Email");
                                 })
-                                );
+                            );
                     })
                     .HorizontalGroup(h =>
                     {
@@ -715,7 +722,9 @@ namespace TestApp.lib
                             {
                                 height = 100
                             });
-                    });
+                    })
+                    .DebugAvalonia(); // enables press F12 to get the avalonia debug window
+                
             }, useIsolatedModelForThisChildForm: true);
         }
     }

--- a/TestApp/model/ContactWindowMainModel.cs
+++ b/TestApp/model/ContactWindowMainModel.cs
@@ -1,3 +1,5 @@
+using System.Collections.ObjectModel;
+
 namespace TestApp.model
 {
     public class ContactWindowMainModel : nac.Forms.model.ViewModelBase
@@ -15,10 +17,18 @@ namespace TestApp.model
             set { SetValue(() => Results, value);}
         }
 
+
+        public ObservableCollection<model.Contact> savedContacts
+        {
+            get { return GetValue(() => savedContacts); }
+            set { SetValue(() => savedContacts, value); }
+        }
+
         public ContactWindowMainModel()
         {
             Contact = new model.Contact();
             Results = "";
+            savedContacts = new ObservableCollection<Contact>();
         }
     }
 }

--- a/nac.Forms/Form.Collections.cs
+++ b/nac.Forms/Form.Collections.cs
@@ -45,7 +45,7 @@ namespace nac.Forms
                 throw new Exception($"Model items source property specified by name [{itemSourcePropertyName}] must be a IEnumerable<T>");
             }
 
-            AddBinding<IEnumerable<T>>(itemSourcePropertyName, itemsCtrl, ItemsControl.ItemsProperty,
+            AddBinding<IEnumerable>(itemSourcePropertyName, itemsCtrl, ItemsControl.ItemsProperty,
                 isTwoWayDataBinding: true);
 
             // handle selection changed
@@ -84,7 +84,7 @@ namespace nac.Forms
 
             
             // item source binding
-            AddBinding<IEnumerable<T>>(modelFieldName: itemSourceModelName,
+            AddBinding<IEnumerable>(modelFieldName: itemSourceModelName,
                                         control: dp,
                                         property: Avalonia.Controls.ComboBox.ItemsProperty,
                                         isTwoWayDataBinding:true);

--- a/nac.Forms/Form.Collections.cs
+++ b/nac.Forms/Form.Collections.cs
@@ -46,7 +46,7 @@ namespace nac.Forms
             }
 
             AddBinding<IEnumerable>(itemSourcePropertyName, itemsCtrl, ItemsControl.ItemsProperty,
-                isTwoWayDataBinding: true);
+                isTwoWayDataBinding: false);
 
             // handle selection changed
             itemsCtrl.SelectionChanged += (_s, _args) =>
@@ -87,7 +87,7 @@ namespace nac.Forms
             AddBinding<IEnumerable>(modelFieldName: itemSourceModelName,
                                         control: dp,
                                         property: Avalonia.Controls.ComboBox.ItemsProperty,
-                                        isTwoWayDataBinding:true);
+                                        isTwoWayDataBinding:false);
             
             // selected item binding
             AddBinding<object>(modelFieldName: selectedItemModelName,

--- a/nac.Forms/Form.Collections.cs
+++ b/nac.Forms/Form.Collections.cs
@@ -31,7 +31,7 @@ namespace nac.Forms
                 {
                     var rowForm = new Form(__app: this.app, _model: new lib.BindableDynamicDictionary());
                     // this has to have a unique model
-                    rowForm.Model[SpecialModelKeys.DataContext] = itemModel;
+                    rowForm.DataContext = itemModel;
                     populateItemRow(rowForm);
 
                     rowForm.Host.DataContext = itemModel;
@@ -40,7 +40,7 @@ namespace nac.Forms
                 });
             }
             
-            if( !(this.Model[itemSourcePropertyName] is IEnumerable<T>))
+            if( !(getModelValue(itemSourcePropertyName) is IEnumerable<T>))
             {
                 throw new Exception($"Model items source property specified by name [{itemSourcePropertyName}] must be a IEnumerable<T>");
             }
@@ -77,7 +77,7 @@ namespace nac.Forms
             lib.styleUtil.style(this,dp,style);
             
             // Just as a safety check, make them init the model first
-            if( !(this.Model[itemSourceModelName] is IEnumerable<T>))
+            if( !(getModelValue(itemSourceModelName) is IEnumerable<T>))
             {
                 throw new Exception($"Model {nameof(itemSourceModelName)} source property specified by name [{itemSourceModelName}] must be a IEnumerable<T>");
             }
@@ -101,7 +101,7 @@ namespace nac.Forms
                 {
                     var rowForm = new Form(__app: this.app, _model: new lib.BindableDynamicDictionary());
                     // this has to have a unique model
-                    rowForm.Model[SpecialModelKeys.DataContext] = itemModel;
+                    rowForm.DataContext = itemModel;
                     populateItemRow(rowForm);
 
                     rowForm.Host.DataContext = itemModel;

--- a/nac.Forms/Form.ExposeInternals.cs
+++ b/nac.Forms/Form.ExposeInternals.cs
@@ -26,7 +26,7 @@ namespace nac.Forms
         // public version of AddBinding
         public void _Extend_AddBinding<T>(string modelFieldName,
             AvaloniaObject control,
-            AvaloniaProperty property,
+            AvaloniaProperty<T> property,
             bool isTwoWayDataBinding = false)
         {
             AddBinding<T>(modelFieldName: modelFieldName,

--- a/nac.Forms/Form.FileSystem.cs
+++ b/nac.Forms/Form.FileSystem.cs
@@ -18,7 +18,7 @@ namespace nac.Forms
         )
         {
             // initialize the filename in the model
-            this.Model[fieldName] = "";
+            setModelValue(fieldName, "");
 
             var filePicker = new controls.FilePicker();
 

--- a/nac.Forms/Form.Primatives.cs
+++ b/nac.Forms/Form.Primatives.cs
@@ -32,7 +32,7 @@ namespace nac.Forms
 
 			if( defaultValue != null)
             {
-                this.Model[modelFieldName] = defaultValue;
+                setModelValue(modelFieldName, defaultValue);
             }
 
             AddRowToHost(label);

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -249,6 +249,20 @@ namespace nac.Forms
                 }
             }
         }
+
+
+        public void setModelValue(string modelFieldName, object val)
+        {
+            if (this.Model.HasKey(model.SpecialModelKeys.DataContext))
+            {
+                var dataContext = this.Model[SpecialModelKeys.DataContext];
+                setDataContextValue(dataContext, modelFieldName, val);
+            }
+            else
+            {
+                this.Model[modelFieldName] = val;
+            }
+        }
         
         
         private void AddBinding<T>(string modelFieldName,

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -289,12 +289,15 @@ namespace nac.Forms
 
                     // need to fire it's current value.  Then start watching for changes
                     var currentValue = getDataContextValue(dataContext, modelFieldName);
+                    log.Debug(
+                        $"AddBinding-Model Value Change [*Initial* Field: {modelFieldName}; New Value: {currentValue}]");
                     FireOnNextWithValue<T>(bindingSource, currentValue );
 
                     prop.PropertyChanged += (_s,_args) => {
                         if( string.Equals(_args.PropertyName, modelFieldName, StringComparison.OrdinalIgnoreCase))
                         {
                             var newCurrentValue = getDataContextValue(dataContext, modelFieldName);
+                            log.Debug($"AddBinding-Model Value Change [Field: {modelFieldName}; New Value: {currentValue}]");
                             FireOnNextWithValue<T>(bindingSource, newCurrentValue );
                         }
                     };
@@ -316,8 +319,6 @@ namespace nac.Forms
                     FireOnNext<T>(bindingSource, modelFieldName);
                 });
             }
-
-
             // If they say two way then we setup a watch on the property observable and apply the values back to the model
             if(isTwoWayDataBinding)
             {
@@ -326,15 +327,13 @@ namespace nac.Forms
 
                 controlValueChangesObservable.Subscribe(newVal =>
                 {
-                    if( bindingIsDataContext){
-                        // set the property
-                        setDataContextValue(dataContext, modelFieldName,  newVal);
-                    }else {
-                        this.Model[modelFieldName] = newVal;
-                    }
-                    
+                    log.Debug($"AddBinding-TwoWay-Control Value Change [Control Property: {property.Name}; Field: {modelFieldName}; New Value: {newVal}]");
+                    setModelValue(modelFieldName, newVal);
                 });
             }
+            
+            
+            // end of AddBinding
         }
         
 

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -292,12 +292,14 @@ namespace nac.Forms
                     bindingIsDataContext = true;
 
                     // need to fire it's current value.  Then start watching for changes
-                    FireOnNextWithValue<T>(bindingSource, getDataContextValue(dataContext, modelFieldName));
+                    var currentValue = getDataContextValue(dataContext, modelFieldName);
+                    FireOnNextWithValue<T>(bindingSource, currentValue );
 
                     prop.PropertyChanged += (_s,_args) => {
-                        if( string.Equals(_args.PropertyName, modelFieldName, StringComparison.OrdinalIgnoreCase)){
-                            
-                            FireOnNextWithValue<T>(bindingSource, getDataContextValue(dataContext, modelFieldName));
+                        if( string.Equals(_args.PropertyName, modelFieldName, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var newCurrentValue = getDataContextValue(dataContext, modelFieldName);
+                            FireOnNextWithValue<T>(bindingSource, newCurrentValue );
                         }
                     };
                 }

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -6,6 +6,7 @@ using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Data;
 using nac.Forms.lib;
 using nac.Forms.model;
 
@@ -267,17 +268,12 @@ namespace nac.Forms
         
         private void AddBinding<T>(string modelFieldName,
             AvaloniaObject control,
-            AvaloniaProperty property,
+            AvaloniaProperty<T> property,
             bool isTwoWayDataBinding = false)
         {
             // (ideas from here)[http://avaloniaui.net/docs/binding/binding-from-code]
             var bindingSource = new Subject<T>();
-            var bindingSourceObservable = bindingSource.AsObservable()
-                .Select(i =>
-                {
-                    return (object)i;
-                });
-            control.Bind(property, bindingSourceObservable);
+            control.Bind<T>(property, bindingSource.AsObservable());
 
             bool bindingIsDataContext = false;
             object dataContext = null;


### PR DESCRIPTION
Switch List and Dropdown to use getModelValue

Created setModelValue so we could fix a few places where the model was still being directly set, and so those places where incompatible with DataContext