### PR TITLE
Bugfix to DirectoryPath replace setModelValue

### DIFF
--- a/TestApp/Program.cs
+++ b/TestApp/Program.cs
@@ -144,6 +144,11 @@ namespace TestApp
                 },
                 new TestEntry()
                 {
+                    Name  = "Test DirectoryPathFor: Class Model binding Directory Path",
+                    CodeToRun = lib.TestFunctions.TestDirectoryPathFor_ClassBinding
+                },
+                new TestEntry()
+                {
                     Name = "Tabs: Basic Test",
                     CodeToRun = lib.TestFunctions.Test_Tabs_BasicTest
                 },

--- a/TestApp/lib/TestFunctions.cs
+++ b/TestApp/lib/TestFunctions.cs
@@ -437,6 +437,7 @@ namespace TestApp.lib
         {
             parentForm.DisplayChildForm(f =>
             {
+                f.Model["myPath"] = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
                 f.DirectoryPathFor("myPath",
                         onDirectoryPathChanged: (newFilePath) =>
                         {

--- a/TestApp/lib/TestFunctions.cs
+++ b/TestApp/lib/TestFunctions.cs
@@ -451,6 +451,29 @@ namespace TestApp.lib
             });
         }
         
+        public static void TestDirectoryPathFor_ClassBinding(Form parentForm)
+        {
+            parentForm.DisplayChildForm(f =>
+            {
+                var myModel = new model.DirectoryPathFormWindowModel();
+                f.DataContext = myModel;
+
+                myModel.myPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+                
+                f.DirectoryPathFor(nameof(model.DirectoryPathFormWindowModel.myPath),
+                        onDirectoryPathChanged: (newFilePath) =>
+                        {
+                            Console.WriteLine($"New Directory path is: {newFilePath}");
+                            Console.WriteLine($"\t\tModel myPath: {myModel.myPath}");
+                        })
+                    .HorizontalGroup(hg =>
+                    {
+                        hg.Text("You picked directory: ")
+                            .TextFor(nameof(model.DirectoryPathFormWindowModel.myPath));
+                    });
+            });
+        }
+        
         
         
 
@@ -800,6 +823,5 @@ namespace TestApp.lib
 
             }, useIsolatedModelForThisChildForm: true);
         }
-
     }
 }

--- a/TestApp/model/DirectoryPathFormWindowModel.cs
+++ b/TestApp/model/DirectoryPathFormWindowModel.cs
@@ -1,0 +1,11 @@
+﻿namespace TestApp.model;
+
+public class DirectoryPathFormWindowModel: nac.Forms.model.ViewModelBase
+{
+    public string myPath
+    {
+        get { return GetValue(() => myPath); }
+        set { SetValue(() => myPath, value);}
+    }
+    
+}

--- a/nac.Forms/Form.FileSystem.cs
+++ b/nac.Forms/Form.FileSystem.cs
@@ -17,8 +17,7 @@ namespace nac.Forms
             FilePathFor_Functions functions = null
         )
         {
-            // initialize the filename in the model
-            setModelValue(fieldName, "");
+            setModelIfNull(fieldName, "");
 
             var filePicker = new controls.FilePicker();
 
@@ -40,7 +39,7 @@ namespace nac.Forms
         public Form DirectoryPathFor(string fieldName,
             Action<string> onDirectoryPathChanged = null)
         {
-            setModelValue(fieldName, ""); // make sure the model has a value for this to start out
+            setModelIfNull(fieldName, ""); // make sure the model has a value for this to start out
 
             var directoryPicker = new controls.DirectoryPicker();
             

--- a/nac.Forms/Form.Primatives.cs
+++ b/nac.Forms/Form.Primatives.cs
@@ -32,7 +32,7 @@ namespace nac.Forms
 
 			if( defaultValue != null)
             {
-                setModelValue(modelFieldName, defaultValue);
+                setModelIfNull(modelFieldName, defaultValue);
             }
 
             AddRowToHost(label);

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -269,6 +269,29 @@ namespace nac.Forms
                 this.Model[modelFieldName] = val;
             }
         }
+
+
+        public void setModelIfNull(string modelFieldName, object val)
+        {
+            if (this.Model.HasKey(model.SpecialModelKeys.DataContext))
+            {
+                var dataContext = this.Model[SpecialModelKeys.DataContext];
+
+                object currentValue = getDataContextValue(dataContext, modelFieldName);
+                if (currentValue is null)
+                {
+                    setDataContextValue(dataContext, modelFieldName, val);
+                }
+            }
+            else
+            {
+                if (!this.Model.HasKey(modelFieldName) ||
+                    this.Model[modelFieldName] is null)
+                {
+                    this.Model[modelFieldName] = val;
+                }
+            }
+        }
         
         
         private void AddBinding<T>(string modelFieldName,

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -325,7 +325,7 @@ namespace nac.Forms
                         if( string.Equals(_args.PropertyName, modelFieldName, StringComparison.OrdinalIgnoreCase))
                         {
                             var newCurrentValue = getDataContextValue(dataContext, modelFieldName);
-                            log.Debug($"AddBinding-Model Value Change [Field: {modelFieldName}; New Value: {currentValue}]");
+                            log.Debug($"AddBinding-Model Value Change [Field: {modelFieldName}; New Value: {newCurrentValue}]");
                             FireOnNextWithValue<T>(bindingSource, newCurrentValue );
                         }
                     };


### PR DESCRIPTION
We only intended to set the model value if it was null.  If the person set the model then called DirectoryPathFor, we'd want to use that model value as the initial directory path