### PR TITLE
Fix directory picker cancel

### DIFF
--- a/TestApp/lib/TestFunctions.cs
+++ b/TestApp/lib/TestFunctions.cs
@@ -404,18 +404,25 @@ namespace TestApp.lib
             f.DataContext = myModel;
 
             myModel.myPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
-                
+
             f.DirectoryPathFor(nameof(model.DirectoryPathFormWindowModel.myPath),
                     onDirectoryPathChanged: (newFilePath) =>
                     {
-                        Console.WriteLine($"New Directory path is: {newFilePath}");
-                        Console.WriteLine($"\t\tModel myPath: {myModel.myPath}");
+                        model.LogEntry.info($"New Directory path is: {newFilePath}");
+                        model.LogEntry.info($"      Model myPath: {myModel.myPath}");
                     })
                 .HorizontalGroup(hg =>
                 {
                     hg.Text("You picked directory: ")
                         .TextFor(nameof(model.DirectoryPathFormWindowModel.myPath));
-                });
+                })
+                .Text("The below directory picker doesn't start with a path")
+                .DirectoryPathFor(nameof(model.DirectoryPathFormWindowModel.pathWithoutBeingInit),
+                    onDirectoryPathChanged: (newPath) =>
+                    {
+                        model.LogEntry.info($"Old path: {myModel.pathWithoutBeingInit}");
+                        model.LogEntry.info($"New path: {newPath}");
+                    });
         }
         
         

--- a/TestApp/model/DirectoryPathFormWindowModel.cs
+++ b/TestApp/model/DirectoryPathFormWindowModel.cs
@@ -2,6 +2,12 @@
 
 public class DirectoryPathFormWindowModel: nac.Forms.model.ViewModelBase
 {
+    public string pathWithoutBeingInit
+    {
+        get { return GetValue(() => pathWithoutBeingInit); }
+        set { SetValue(() => pathWithoutBeingInit, value); }
+    }
+
     public string myPath
     {
         get { return GetValue(() => myPath); }

--- a/nac.Forms/controls/DirectoryPicker.xaml.cs
+++ b/nac.Forms/controls/DirectoryPicker.xaml.cs
@@ -82,10 +82,6 @@ public class DirectoryPicker: UserControl
         {
             DirectoryPath = result;
         }
-        else
-        {
-            DirectoryPath = "";
-        }
     }
     
     private void DirectoryPath_Changed(AvaloniaPropertyChangedEventArgs e)

--- a/nac.Forms/controls/FilePicker.xaml.cs
+++ b/nac.Forms/controls/FilePicker.xaml.cs
@@ -137,10 +137,6 @@ namespace nac.Forms.controls
             {
                 FilePath = result.First();
             }
-            else
-            {
-                FilePath = "";
-            }
         }
         
         
@@ -166,10 +162,6 @@ namespace nac.Forms.controls
             if (!string.IsNullOrWhiteSpace(result))
             {
                 FilePath = result;
-            }
-            else
-            {
-                FilePath = "";
             }
         }
         


### PR DESCRIPTION
People are expecting that cancel will not modify the model, so change both Directory and File path controls to not blank out the model on cancel path choosing dialogs