### PR TITLE
Make avalonia app manager concept work

### DIFF
--- a/Tests/FormTests.cs
+++ b/Tests/FormTests.cs
@@ -68,6 +68,11 @@ namespace Tests
         [TestMethod]
         public async Task StartUI_SetupSpecialUIThread()
         {
+            nac.Forms.lib.Log.OnNewMessage += (_s, _args) =>
+            {
+                System.Diagnostics.Debug.WriteLine(_args);
+            };
+
             nac.Forms.lib.AvaloniaAppManager.GlobalAppBuilderConfigurFunction = (appBuilder) =>
             {
                 appBuilder.LogToTrace(LogEventLevel.Debug);

--- a/Tests/FormTests.cs
+++ b/Tests/FormTests.cs
@@ -3,6 +3,8 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 using System.Linq;
 using nac.Forms;
+using Avalonia.Logging;
+using System;
 
 // bring in the extensions
 
@@ -59,6 +61,30 @@ namespace Tests
                        .Text("Text Below");
              }, isSplit: true)
                 .Display();
+        }
+
+
+
+        [TestMethod]
+        public async Task StartUI_SetupSpecialUIThread()
+        {
+            nac.Forms.lib.AvaloniaAppManager.GlobalAppBuilderConfigurFunction = (appBuilder) =>
+            {
+                appBuilder.LogToTrace(LogEventLevel.Debug);
+                System.Diagnostics.Debug.WriteLine("[nac.Forms.Testing] - Avalonia LogToTrace Setup");
+            };
+
+            await nac.Forms.lib.AvaloniaAppManager.DisplayForm(async f =>
+            {
+                f.Text("Special UI Thread.  Never use this unless you know why you used it.  Will not work on macos where UI must be on the main thread");
+            });
+
+            await nac.Forms.lib.AvaloniaAppManager.DisplayForm(async f =>
+            {
+                f.Text("A second form on the avalonia App");
+            });
+
+            System.Diagnostics.Debug.WriteLine("Test finished");
         }
         
         

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data;
 using nac.Forms.lib;
 using nac.Forms.model;
@@ -90,10 +91,19 @@ namespace nac.Forms
         {
             var appBuilder = Avalonia.AppBuilder.Configure<nac.Forms.App>();
             beforeAppBuilderInit?.Invoke(appBuilder);
+
             var builder = appBuilder
                 //.LogToDebug(Avalonia.Logging.LogEventLevel.Verbose)
                 .UsePlatformDetect()
                 .SetupWithoutStarting();
+
+            var lifeTime = new ClassicDesktopStyleApplicationLifetime()
+            {
+                ShutdownMode = ShutdownMode.OnExplicitShutdown
+            };
+
+            appBuilder.Instance.ApplicationLifetime = lifeTime;
+            appBuilder.Instance.OnFrameworkInitializationCompleted();
 
             return builder.Instance;
         }

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -97,14 +97,6 @@ namespace nac.Forms
                 .UsePlatformDetect()
                 .SetupWithoutStarting();
 
-            var lifeTime = new ClassicDesktopStyleApplicationLifetime()
-            {
-                ShutdownMode = ShutdownMode.OnExplicitShutdown
-            };
-
-            appBuilder.Instance.ApplicationLifetime = lifeTime;
-            appBuilder.Instance.OnFrameworkInitializationCompleted();
-
             return builder.Instance;
         }
 

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -85,7 +85,8 @@ namespace nac.Forms
 
         public delegate void ConfigureAppBuilder(Avalonia.AppBuilder appBuilder);
 
-        public static Form NewForm(ConfigureAppBuilder beforeAppBuilderInit = null)
+
+        internal static Avalonia.Application SetupAvaloniaApp(ConfigureAppBuilder beforeAppBuilderInit = null)
         {
             var appBuilder = Avalonia.AppBuilder.Configure<nac.Forms.App>();
             beforeAppBuilderInit?.Invoke(appBuilder);
@@ -94,7 +95,13 @@ namespace nac.Forms
                 .UsePlatformDetect()
                 .SetupWithoutStarting();
 
-            var f = new Form(builder.Instance);
+            return builder.Instance;
+        }
+
+        public static Form NewForm(ConfigureAppBuilder beforeAppBuilderInit = null)
+        {
+            var app = SetupAvaloniaApp(beforeAppBuilderInit: beforeAppBuilderInit);
+            var f = new Form(app);
             return f;
         }
 

--- a/nac.Forms/Form.cs
+++ b/nac.Forms/Form.cs
@@ -163,7 +163,7 @@ namespace nac.Forms
             return subWindow.ShowDialog(win);
         }
         
-        private async Task<bool> Display_Internal(int height, int width,
+        internal async Task<bool> Display_Internal(int height, int width,
             Func<Form, Task<bool?>> onClosing = null,
             Func<Form, Task> onDisplay = null,
             bool isDialog = false)

--- a/nac.Forms/lib/AvaloniaAppManager.cs
+++ b/nac.Forms/lib/AvaloniaAppManager.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nac.Forms.lib;
+
+/*
+ THis avalonia app manager is a special thing that is used for launching avalonia windows from a WPF app
+  - It will keep a reference to a "Main" form an spin off child forms for each new thing needed
+    !!REMEMBER!!
+    + On some operating systems like MACOS you cannot run the UI on a seperate thread than the main thread
+    + Allways try and use Display() directly first, and if you run into some situation you can use StartUI
+    + You cannot call this from an existing avalonia app.
+*/
+
+public static class AvaloniaAppManager
+{
+    public static nac.Forms.Form.ConfigureAppBuilder GlobalAppBuilderConfigurFunction;
+    private static nac.Forms.Form mainForm;
+    private static System.Threading.Thread mainThread;
+
+    private static Task EnsureMainForm()
+    {
+        var promise = new System.Threading.Tasks.TaskCompletionSource<bool>();
+
+        if (mainForm != null)
+        {
+            return Task.FromResult(true);
+        }
+
+        // mainForm isn't setup yet
+        mainThread = new Thread(async () =>
+        {
+            mainForm = nac.Forms.Form.NewForm(beforeAppBuilderInit: GlobalAppBuilderConfigurFunction);
+
+            mainForm.Display(height: 0,
+                width: 0,
+                onDisplay: async (_f) =>
+                {
+                    promise.SetResult(true);
+                });
+        });
+        // configure the thread
+        mainThread.SetApartmentState(ApartmentState.STA);
+        mainThread.Start();
+
+        return promise.Task;
+    }
+
+
+
+    public static async Task<bool> DisplayForm(Action<nac.Forms.Form> buildFormFunction,
+                                    int height=600,
+                                    int width = 800,
+                                    Func<Form, Task<bool?>> onClosing = null,
+                                    Func<Form, Task> onDisplay = null)
+    {
+        await EnsureMainForm();
+        await mainForm.InvokeAsync(async () =>
+        {
+            await mainForm.DisplayChildForm(setupChildForm: buildFormFunction,
+            height: height,
+            width: width,
+            onClosing: onClosing,
+            onDisplay: onDisplay,
+            useIsolatedModelForThisChildForm: true,
+            isDialog: true);
+
+        });
+
+        return true;
+    }
+
+
+}

--- a/nac.Forms/lib/AvaloniaAppManager.cs
+++ b/nac.Forms/lib/AvaloniaAppManager.cs
@@ -17,6 +17,7 @@ namespace nac.Forms.lib;
 
 public static class AvaloniaAppManager
 {
+    private static lib.Log log = new();
     public static nac.Forms.Form.ConfigureAppBuilder GlobalAppBuilderConfigurFunction;
     
     private static Task<bool> DisplayFormWithNewAvaloniaApp(Action<nac.Forms.Form> buildFormFunction,
@@ -43,6 +44,7 @@ public static class AvaloniaAppManager
                         return stopClose;
                     }
 
+                    promise.SetResult(true);
                     return false;
                 }, onDisplay: onDisplay);
         });
@@ -91,8 +93,10 @@ public static class AvaloniaAppManager
         Func<Form, Task<bool?>> onClosing = null,
         Func<Form, Task> onDisplay = null)
     {
+        log.Info("Starting display of form");
         if (Avalonia.Application.Current == null)
         {
+            log.Info("Creating new Avalonia Application");
             return await DisplayFormWithNewAvaloniaApp(buildFormFunction,
                 height: height,
                 width: width,
@@ -100,6 +104,7 @@ public static class AvaloniaAppManager
                 onDisplay: onDisplay);
         }
 
+        log.Info("Avalonia Application Already Exists");
         return await DisplayFormWithExistingApp(app: Avalonia.Application.Current,
             buildFormFunction: buildFormFunction,
             height: height,

--- a/nac.Forms/lib/AvaloniaAppManager.cs
+++ b/nac.Forms/lib/AvaloniaAppManager.cs
@@ -65,11 +65,15 @@ public static class AvaloniaAppManager
         
         await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(async () =>
         {
+            log.Info("Inside UIThread InvokeAsync");
+            // Sending a null model means it will be a parent form
             var form = new nac.Forms.Form(__app: app,
-                _model: new nac.Forms.lib.BindableDynamicDictionary());
+                _model: null);
 
+            log.Info("Building Form");
             buildFormFunction(form);
-            
+
+            log.Info("DIsplay Internal Form");
             await form.Display_Internal(height: height,
                 width: width,
                 onClosing: async (_f) =>

--- a/nac.Forms/lib/Log.cs
+++ b/nac.Forms/lib/Log.cs
@@ -16,6 +16,11 @@ namespace nac.Forms.lib
             {
                 this.EventDate = DateTime.Now;
             }
+
+            public override string ToString()
+            {
+                return $"[{EventDate:yyyy-MM-dd hh:mm:ss tt}] - {Level} - {CallingMemberName} - {Message}"; 
+            }
         }
         
         public static event EventHandler<LogMessage> OnNewMessage;


### PR DESCRIPTION
This is to create Avalonia Windows inside a WPF app in Windows
I do not believe the AppManager concept would work on macos, but neither will WPF
For macos/linux use the library as you normally would (Examples, and all of the code called hasn't changed)